### PR TITLE
feat: add update version alias input for release workflow

### DIFF
--- a/.github/workflows/_test-aws-rds-snapshot.yaml
+++ b/.github/workflows/_test-aws-rds-snapshot.yaml
@@ -1,22 +1,23 @@
 name: Test AWS RDS Snapshot and Share
 
-# on:
-#   pull_request:
-#     branches:
-#       - main
-#     paths:
-#       - '.github/workflows/_test-aws-rds-snapshot.yaml'
-#       - '.github/workflows/aws-rds-snapshot.yaml'
-#   push:
-#     paths:
-#       - '.github/workflows/_test-aws-rds-snapshot.yaml'
-#       - '.github/workflows/aws-rds-snapshot.yaml'
+on:
+  # pull_request:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - '.github/workflows/_test-aws-rds-snapshot.yaml'
+  #     - '.github/workflows/aws-rds-snapshot.yaml'
+  # push:
+  #   paths:
+  #     - '.github/workflows/_test-aws-rds-snapshot.yaml'
+  #     - '.github/workflows/aws-rds-snapshot.yaml'
+  workflow_dispatch:
 
-## !!! 
-## This workflow file was not fully tested due to the lack 
-## of integration with multiple AWS accounts and the absence 
-## of a running RDS instance when it was developed. 
-## Instead, it was thoroughly tested in a shared workflow 
+## !!!
+## This workflow file was not fully tested due to the lack
+## of integration with multiple AWS accounts and the absence
+## of a running RDS instance when it was developed.
+## Instead, it was thoroughly tested in a shared workflow
 ## for a different project.
 ## !!!
 
@@ -53,7 +54,7 @@ jobs:
       share_snapshot_retries: 5
       share_snapshot_wait_interval_seconds: 25
       aws_tags: '"Key=Trigger,Value=GithubActions" "Key=Repository,Value=DND-IT/github-workflows"'
-  
+
   check-account-b:
     needs:
       - account-a-snapshot
@@ -75,10 +76,10 @@ jobs:
               --query 'DBSnapshots[?DBInstanceIdentifier==`${{ vars.AWS_ACCOUNT_A_RDS_IDENTIFIER }}`]'
           )
           echo "$_SNAPSHOTS"
-          
+
           # 'jq -e' will exist with non-zero if condition is false
           echo "$_SNAPSHOTS" | jq -er '. | length != 0'
-  
+
   cleanup-account-a:
     needs:
       - check-account-b

--- a/.github/workflows/gh-release-on-main.yaml
+++ b/.github/workflows/gh-release-on-main.yaml
@@ -7,6 +7,11 @@ on:
         description: "File path containing the extra metadata to append to the release version, if not specified the standard semver is applied"
         type: string
         default: ""
+      update_version_aliases:
+        description: "Automatically update version alias tags (e.g., v1 and v1.2) to point to the latest release."
+        type: boolean
+        default: true
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -87,7 +92,7 @@ jobs:
           generate_release_notes: true
 
       - name: Update major and minor version tags
-        if: steps.version_increment.outputs.RELEASE == 'true'
+        if: steps.version_increment.outputs.RELEASE == 'true' && inputs.update_version_aliases == 'true'
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"


### PR DESCRIPTION
In some cases we dont want to have alias since they need to be semver (tf registry)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
- [ ] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
