### PR TITLE
feat: replace / with - in all image_tag inputs

### DIFF
--- a/.github/workflows/_test-docker.yaml
+++ b/.github/workflows/_test-docker.yaml
@@ -16,7 +16,7 @@ jobs:
       aws_region: ${{ vars.aws_region }}
       aws_role_name: ${{ vars.aws_role_name }}
       image_name: test-docker-build-push
-      image_tag: ${{ github.sha }}
+      image_tag: image/with/slash
       docker_context: tests/docker
       docker_push: false
 

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -94,12 +94,18 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
+      - name: Sanitize Image Tag
+        run: |
+          IMAGE_TAG="${{ inputs.image_tag }}"
+          IMAGE_TAG="${IMAGE_TAG//\//-}"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+
       - name: Build and export
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.image_name || vars.image_name || github.event.repository.name }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           DOCKER_CTX: ${{ inputs.docker_context || vars.docker_context || '.' }}
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path || vars.dockerfile_path }} # upstream defaults to {DOCKER_CTX}/Dockerfile
           DOCKER_TARGET: ${{ inputs.docker_target || vars.docker_target }}

--- a/.github/workflows/docker-buildx-push-ecr.yaml
+++ b/.github/workflows/docker-buildx-push-ecr.yaml
@@ -138,12 +138,20 @@ jobs:
       - name: Log in to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
+
+      - name: Normalize Image Tag
+        id: normalize-image-tag
+        run: |
+          IMAGE_TAG="${{ inputs.image_tag }}"
+          IMAGE_TAG="${IMAGE_TAG//\//-}"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+
       - name: Build(${{ matrix.platform }}) and push(${{ inputs.docker_push }}) to ECR
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.image_name || vars.image_name || github.event.repository.name }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           PUSH_SHA_TAG: ${{ inputs.image_push_sha_tag }}
           DOCKER_CTX: ${{ inputs.docker_context || vars.docker_context || '.' }}
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path || vars.dockerfile_path }} # upstream defaults to {DOCKER_CTX}/Dockerfile
@@ -188,11 +196,17 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
+      - name: Sanitize Image Tag
+        run: |
+          IMAGE_TAG="${{ inputs.image_tag }}"
+          IMAGE_TAG="${IMAGE_TAG//\//-}"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+
       - name: Create and push multi-arch manifest
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.image_name || vars.image_name || github.event.repository.name }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: |
           IMAGE_PATH="${{ env.REGISTRY }}/${{ env.REPOSITORY }}"
           SHA="${{ github.sha }}"
@@ -227,7 +241,7 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.image_name || vars.image_name || github.event.repository.name }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: |
           IMAGE_PATH="${{ env.REGISTRY }}/${{ env.REPOSITORY }}"
           PUSH_SHA_TAG="${{ inputs.image_push_sha_tag }}"

--- a/.github/workflows/docker-push-ecr.yaml
+++ b/.github/workflows/docker-push-ecr.yaml
@@ -59,12 +59,18 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
+      - name: Sanitize Image Tag
+        run: |
+          IMAGE_TAG="${{ inputs.image_tag }}"
+          IMAGE_TAG="${IMAGE_TAG//\//-}"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+
       - name: Tag and push docker image to Amazon ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.image_name || vars.image_name || github.event.repository.name}}
           SOURCE_TAG: ${{ github.event.pull_request.head.sha || github.sha }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           BRANCH: ${{ github.ref_name }}
           ARTIFACT_NAME: ${{ inputs.artifact_name || inputs.image_name || vars.image_name || github.event.repository.name }}
         run: |


### PR DESCRIPTION

## Description
Sanitise the image_tag input

## Motivation and Context
oci does not support / in the name.

This is mainly for renovate branches - renovate/ since we are tagging the branch name in most image build workflows.



## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

## Github Conventional Commit Release
[https://dnd-it.github.io/github-workflows/workflows/gh-release-on-main/](https://dnd-it.github.io/github-workflows/workflows/gh-release-on-main/)
