### PR TITLE
disable multi arch workflow tests

### DIFF
--- a/.github/workflows/_test-docker-multi-arch.yaml
+++ b/.github/workflows/_test-docker-multi-arch.yaml
@@ -1,13 +1,14 @@
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/_test-docker-multi-arch.yaml"
-      - ".github/workflows/docker-buildx-push-ecr.yaml"
-      - "tests/docker-multi-arch/**"
-      - "tests/terraform/docker-buildc-ecr/**"
-
+  # TODO: fix tests as they are not working correctly
+  # pull_request:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - ".github/workflows/_test-docker-multi-arch.yaml"
+  #     - ".github/workflows/docker-buildx-push-ecr.yaml"
+  #     - "tests/docker-multi-arch/**"
+  #     - "tests/terraform/docker-buildc-ecr/**"
+  workflow_dispatch:
 jobs:
   ## Setups
   setup_docker_ecr:
@@ -64,7 +65,7 @@ jobs:
   ## Cleanups
   # TODO: enable after tests finished
   # cleanup_docker_ecr:
-  #   needs: 
+  #   needs:
   #     - setup_docker_ecr
   #     - test_docker_buildx_amd64_push_ecr
   #     - test_docker_buildx_arm64_push_ecr


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

## Github Conventional Commit Release
[https://dnd-it.github.io/github-workflows/workflows/gh-release-on-main/](https://dnd-it.github.io/github-workflows/workflows/gh-release-on-main/)
