### PR TITLE
feat: add input validation

### DIFF
--- a/.github/workflows/gitops-image-tag.yaml
+++ b/.github/workflows/gitops-image-tag.yaml
@@ -41,9 +41,12 @@ on:
         type: string
         default: ${{ github.event.repository.default_branch }}
       app_id:
-        description: 'GitHub App ID for generating a token. Required if using GitHub App authentication. app_private_key must be set in the secrets.'
+        description: '[DEPRECATED] Use secret instead: GitHub App ID for generating a token. Required if using GitHub App authentication. app_private_key must be set in the secrets.'
         type: string
     secrets:
+      app_id:
+        description: 'GitHub App ID for generating a token. Required if using GitHub App authentication.'
+        required: false
       app_private_key:
         description: 'Private key for the GitHub App. Required if using GitHub App authentication.'
         required: false
@@ -57,6 +60,16 @@ jobs:
 
       - name: Update Helm values files
         run: |
+          # Validate inputs
+          if [ -z "${{ inputs.image_tag }}" ]; then
+            echo "Error: image_tag input cannot be empty"
+            exit 1
+          fi
+          if [ -z "${{ inputs.values_files }}" ]; then
+            echo "Error: values_files input cannot be empty"
+            exit 1
+          fi
+
           echo "Files to update:"
           echo "${{ inputs.values_files }}"
           echo ""

--- a/docs/workflows/gitops-image-tag.md
+++ b/docs/workflows/gitops-image-tag.md
@@ -19,7 +19,7 @@ This GitHub Actions workflow updates the image tag in specified yaml files. It c
 | `auto_merge` | <p>Enable auto-merge for the pull request. Only works if create_pr is true.</p> | `boolean` | `false` | `false` |
 | `branch_name_prefix` | <p>Prefix for the branch name.</p> | `string` | `false` | `helm-values` |
 | `target_branch` | <p>The target branch for the pull request. Defaults the default branch of the repository.</p> | `string` | `false` | `${{ github.event.repository.default_branch }}` |
-| `app_id` | <p>GitHub App ID for generating a token. Required if using GitHub App authentication. app<em>private</em>key must be set in the secrets.</p> | `string` | `false` | `""` |
+| `app_id` | <p>[DEPRECATED] Use secret instead: GitHub App ID for generating a token. Required if using GitHub App authentication. app<em>private</em>key must be set in the secrets.</p> | `string` | `false` | `""` |
 <!-- action-docs-inputs source=".github/workflows/gitops-image-tag.yaml" -->
 
 <!-- action-docs-outputs source=".github/workflows/gitops-image-tag.yaml" -->
@@ -92,7 +92,7 @@ jobs:
       # Default: ${{ github.event.repository.default_branch }}
 
       app_id:
-      # GitHub App ID for generating a token. Required if using GitHub App authentication. app_private_key must be set in the secrets.
+      # [DEPRECATED] Use secret instead: GitHub App ID for generating a token. Required if using GitHub App authentication. app_private_key must be set in the secrets.
       #
       # Type: string
       # Required: false


### PR DESCRIPTION
support app_id as a secret

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
- [ ] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

## Github Conventional Commit Release
[https://dnd-it.github.io/github-workflows/workflows/gh-release-on-main/](https://dnd-it.github.io/github-workflows/workflows/gh-release-on-main/)
