### PR TITLE
feat: adding instance status in RDS verify step

### DIFF
--- a/.github/workflows/aws-rds-snapshot.yaml
+++ b/.github/workflows/aws-rds-snapshot.yaml
@@ -87,7 +87,7 @@ jobs:
         run: |
           aws rds describe-db-instances \
             --db-instance-identifier "${{ inputs.source_rds_identifier }}" | \
-              jq '.DBInstances[].TagList'
+              jq '.DBInstances[] | {DBInstanceStatus, TagList}'
 
       - name: Create Snapshot
         id: snapshot


### PR DESCRIPTION
## Description
AWS RDS Snapshot pipeline was not displaying the Instance Status when checking the db.

## Motivation and Context
Pipeline was failing without no reason saying "instance not available" even thou when checking through CLI was showing as available. This change will display the current status right before attempting the snapshot removing the "timing" concern when checking the status.

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
- [ ] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

## Github Conventional Commit Release
[https://dnd-it.github.io/github-workflows/workflows/gh-release/](https://dnd-it.github.io/github-workflows/workflows/gh-release/)
