### PR TITLE
feat: new REQUIREMENTS_FILEPATH for lambda-python wf

### DIFF
--- a/.github/workflows/lambda-python.yaml
+++ b/.github/workflows/lambda-python.yaml
@@ -36,7 +36,6 @@ jobs:
     env:
       PYTHON_VERSION: ${{ inputs.python_version }}
       SOURCE_DIR: ${{ inputs.source_dir }}
-      REQUIREMENTS_FILEPATH: ${{ inputs.requirements_filepath }}
     
     defaults:
       run:
@@ -54,7 +53,7 @@ jobs:
       - name: Download Python modules
         run: |
           mkdir package
-          pip install -r ${{ env.REQUIREMENTS_FILEPATH }} -t package
+          pip install -r "${{ inputs.requirements_filepath }}" -t package
 
       - name: Create Zipfile
         working-directory: .


### PR DESCRIPTION
## Description
Adding an option to use a requirements.txt file in a different path other than source_dir.

## Motivation and Context
A single requirements.txt doesn't always "fits-all", some projects have shared resources and smaller scripts and fewer requirements.
This change allows a small script to have it's own dependencies instead of relies on root's requirements.txt.

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
- [ ] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

## Github Conventional Commit Release
[https://dnd-it.github.io/github-workflows/workflows/gh-release/](https://dnd-it.github.io/github-workflows/workflows/gh-release/)
