### PR TITLE
Update permissions to include packages access

### DIFF
--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -68,6 +68,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: read # allow access to private NPM packages hosted on Github 
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
Allow access to private NPM packages hosted on GitHub.

## Description
add  [repos](packages: read) to docker build shared workflow

## Motivation and Context
Disco is using this workflow to build the images. I would like to be able to use a private npm registry https://github.com/DND-IT/feed-openapi/pkgs/npm/feed-client

## Breaking Changes
None

## How Has This Been Tested?
Only for non docker builds in non shared workflow https://github.com/DND-IT/disco-astro/pull/756/changes#diff-b0f56ea695baa6e71c78061bfbb77e1f56fc21b23375474e429db48f77f045b5

## Github Conventional Commit Release
[https://dnd-it.github.io/github-workflows/workflows/gh-release/](https://dnd-it.github.io/github-workflows/workflows/gh-release/)
