### PR TITLE
fix(gitops-helm-diff): give PR comments a per-invocation identity

### DIFF
--- a/.github/workflows/gitops-helm-diff.yaml
+++ b/.github/workflows/gitops-helm-diff.yaml
@@ -31,6 +31,10 @@ on:
         description: 'Name to give to the Helm repository'
         type: string
         default: 'dnd-it'
+      comment_header:
+        description: 'Unique identity for the PR comment. Lets multiple invocations (e.g. one per chart in a matrix) post separate comments that each update in place instead of overwriting each other. Defaults to helm_chart_path.'
+        type: string
+        default: ''
       debug:
         description: 'Enable debug output'
         type: string
@@ -41,6 +45,7 @@ env:
   ENVIRONMENTS_PATH: ${{ inputs.environments_path }}
   OUTPUT_PATH: ${{ inputs.output_path }}
   HELM_RELEASE_NAME: ${{ inputs.helm_release_name }}
+  COMMENT_HEADER: ${{ inputs.comment_header || inputs.helm_chart_path }}
 
 jobs:
   diff:
@@ -122,7 +127,10 @@ jobs:
         id: process-envs
         run: |
           mkdir -p ${{ env.OUTPUT_PATH }}
-          echo "## Helm Deployment Changes" > ${{ env.OUTPUT_PATH }}/all_diffs.md
+          # Sticky-comment marker: gives this invocation a stable identity so re-runs
+          # update in place, and multiple invocations (e.g. one per chart) don't collide.
+          echo "<!-- gitops-helm-diff:${COMMENT_HEADER} -->" > ${{ env.OUTPUT_PATH }}/all_diffs.md
+          echo "## Helm Deployment Changes" >> ${{ env.OUTPUT_PATH }}/all_diffs.md
           echo "" >> ${{ env.OUTPUT_PATH }}/all_diffs.md
 
           HAS_CHANGES=false
@@ -170,8 +178,25 @@ jobs:
 
       - name: Post diff as comment on PR
         if: steps.process-envs.outputs.has_changes == 'true'
-        run: |
-          gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file ${{ env.OUTPUT_PATH }}/all_diffs.md --edit-last || \
-          gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file ${{ env.OUTPUT_PATH }}/all_diffs.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          MARKER="<!-- gitops-helm-diff:${COMMENT_HEADER} -->"
+
+          # Find an existing comment with this invocation's marker so we update it
+          # in place instead of overwriting another chart's comment.
+          # --paginate applies --jq per page, so emit one id per line and pick the last.
+          COMMENT_ID=$(gh api \
+            "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | tail -n1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -F body=@${{ env.OUTPUT_PATH }}/all_diffs.md
+          else
+            gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} \
+              --body-file ${{ env.OUTPUT_PATH }}/all_diffs.md
+          fi

--- a/docs/workflows/gitops-helm-diff.md
+++ b/docs/workflows/gitops-helm-diff.md
@@ -18,6 +18,7 @@ This GitHub Action generates a diff of Helm chart templates between the current 
 | `helm_release_name` | <p>Name to use for the Helm release when templating</p> | `string` | `false` | `app` |
 | `helm_repo_url` | <p>URL of the Helm repository to add</p> | `string` | `false` | `https://dnd-it.github.io/helm-charts` |
 | `helm_repo_name` | <p>Name to give to the Helm repository</p> | `string` | `false` | `dnd-it` |
+| `comment_header` | <p>Unique identity for the PR comment. Lets multiple invocations (e.g. one per chart in a matrix) post separate comments that each update in place instead of overwriting each other. Defaults to helm<em>chart</em>path.</p> | `string` | `false` | `""` |
 | `debug` | <p>Enable debug output</p> | `string` | `false` | `false` |
 <!-- action-docs-inputs source=".github/workflows/gitops-helm-diff.yaml" -->
 
@@ -81,6 +82,13 @@ jobs:
       # Type: string
       # Required: false
       # Default: dnd-it
+
+      comment_header:
+      # Unique identity for the PR comment. Lets multiple invocations (e.g. one per chart in a matrix) post separate comments that each update in place instead of overwriting each other. Defaults to helm_chart_path.
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
 
       debug:
       # Enable debug output


### PR DESCRIPTION
## Summary

Fixes #120 — `gitops-helm-diff.yaml` overwrote its own PR comments when invoked more than once for the same PR (e.g. a matrix that fans out one invocation per changed chart).

The final step used `gh pr comment --edit-last`, which edits the bot's most recent comment with **no per-invocation identity**, so every invocation edited the *same* comment and only the last writer's diff survived.

## Changes

- **New `comment_header` input** (defaults to `helm_chart_path`) giving each invocation a stable identity.
- The diff body is prefixed with a sticky-comment marker `<!-- gitops-helm-diff:<header> -->`.
- The post step now looks up the existing comment by its marker and updates **that** comment in place via the API, or creates a new one if none exists.

## Behavior

- **Single-chart usage:** unchanged — each run updates its own comment in place.
- **Multi-chart / matrix usage:** works out of the box — each chart gets a distinct marker from `helm_chart_path`, so each keeps its own comment that updates across re-runs. Callers can override with `comment_header`.

Docs regenerated via `make gen_docs_run`.