### PR TITLE
fix(gitops-image-tag): remove invalid continue-on-error from test job

### DIFF
--- a/.github/workflows/_test-gitops-image-tag.yaml
+++ b/.github/workflows/_test-gitops-image-tag.yaml
@@ -31,6 +31,9 @@ jobs:
       create_pr: false
       dry_run: true
 
+  # Intentionally red: this job MUST fail (neither image_name nor image_tag_keys
+  # is given). Reusable-workflow jobs can't use continue-on-error, so its failure
+  # marks the run red by design. validate_failure below asserts it failed.
   test_validation_fails_without_mode:
     name: Test validation (no image_name or keys)
     uses: ./.github/workflows/gitops-image-tag.yaml
@@ -39,12 +42,11 @@ jobs:
       values_files: "tests/gitops-image-tag/values.yaml"
       create_pr: false
       dry_run: true
-    # This job is expected to fail — validation rejects missing image_name + image_tag_keys
-    continue-on-error: true
 
   validate_failure:
     name: Validate input validation works
     needs: test_validation_fails_without_mode
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check that validation job failed

--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -94,7 +94,7 @@ jobs:
           private-key: ${{ secrets.app_private_key }}
 
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -94,7 +94,7 @@ jobs:
           private-key: ${{ secrets.app_private_key }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -109,7 +109,7 @@ jobs:
         uses: dflook/terraform-apply@5489b988934a50bf1489d5b7c5253b46520a7dca # v2
         env:
           TERRAFORM_PRE_RUN: |
-            AWS_CLI_VERSION=2.15.36
+            AWS_CLI_VERSION=2.36.1
             if [ -z "${{ inputs.tf_pre_run }}" ]; then
               curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq -o awscliv2.zip && ./aws/install
             else


### PR DESCRIPTION
## What

The `_test-gitops-image-tag.yaml` workflow always failed with a *"workflow file issue"* and **no jobs ran** (e.g. [run 29568572567](https://github.com/DND-IT/github-workflows/actions/runs/29568572567)).

## Root cause

The `test_validation_fails_without_mode` job calls a reusable workflow via `uses:` **and** set `continue-on-error: true`. GitHub only permits `name`, `uses`, `with`, `secrets`, `needs`, `if`, and `permissions` on reusable-workflow-calling jobs, so it rejected the entire file before executing anything. Confirmed with actionlint.

## Fix

- Removed the invalid `continue-on-error: true`.
- Added `if: always()` to `validate_failure` so it still runs and asserts the negative-path job failed as expected.
- Documented that the negative job is intentionally red.

## Notes

- The negative job (`test_validation_fails_without_mode`) still fails **by design** — a reusable-workflow job can't be `continue-on-error`, so its failure marks the overall run red. `validate_failure` confirms the validation guard works.
- This `fix:` commit also serves as a smoke test of the new git-cliff single-release process on merge to `main`.