### PR TITLE
fix(deps): bump actions/checkout to v7.0.0 in gitops-image-tag

### DIFF
--- a/.github/workflows/gitops-image-tag.yaml
+++ b/.github/workflows/gitops-image-tag.yaml
@@ -69,7 +69,7 @@ jobs:
           private-key: ${{ secrets.app_private_key }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.0
 
       - name: Validate inputs
         run: |


### PR DESCRIPTION
Single-workflow change to test the automated release process end-to-end.

Bumps `actions/checkout` from `@v6` to `@v7.0.0` (latest) in `gitops-image-tag.yaml`, matching the pin already used in `gh-release.yaml`.

Expected: on merge to `main`, git-cliff cuts a single **patch** release (v4.0.1 → v4.0.2) with one changelog entry under Bug Fixes.