### PR TITLE
feat(release): add per-workflow scoped releases alongside umbrella

### DIFF
--- a/.github/workflows/_test-gh.yaml
+++ b/.github/workflows/_test-gh.yaml
@@ -67,6 +67,35 @@ jobs:
           fi
           echo "Scoped tag format correct: $TAG"
 
+  test_file_scoped_dry_run:
+    name: Test dry-run (scoped to a single workflow file)
+    uses: ./.github/workflows/gh-release.yaml
+    with:
+      service_name: gitops-image-tag
+      service_path: .github/workflows/gitops-image-tag.yaml
+      dry_run: true
+
+  test_file_scoped_outputs:
+    name: Validate file-scoped outputs
+    needs: test_file_scoped_dry_run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Display outputs
+        run: |
+          echo "new_release_published: ${{ needs.test_file_scoped_dry_run.outputs.new_release_published }}"
+          echo "new_release_version: ${{ needs.test_file_scoped_dry_run.outputs.new_release_version }}"
+          echo "new_release_git_tag: ${{ needs.test_file_scoped_dry_run.outputs.new_release_git_tag }}"
+
+      - name: Validate file-scoped tag format
+        if: needs.test_file_scoped_dry_run.outputs.new_release_published == 'true'
+        run: |
+          TAG="${{ needs.test_file_scoped_dry_run.outputs.new_release_git_tag }}"
+          if [[ "$TAG" != gitops-image-tag-v* ]]; then
+            echo "::error::Expected tag to start with 'gitops-image-tag-v', got: $TAG"
+            exit 1
+          fi
+          echo "File-scoped tag format correct: $TAG"
+
   test_pr_dry_run:
     name: Test PR context (auto dry-run)
     uses: ./.github/workflows/gh-release.yaml

--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -178,6 +178,18 @@ jobs:
             echo "No existing tags found — first release"
           fi
 
+      - name: Compute commit path filter
+        id: filter
+        run: |
+          SERVICE_PATH="${{ inputs.service_path }}"
+          if [ -z "$SERVICE_PATH" ]; then
+            echo "include_path=" >> $GITHUB_OUTPUT
+          elif [ -f "$SERVICE_PATH" ]; then
+            echo "include_path=$SERVICE_PATH" >> $GITHUB_OUTPUT
+          else
+            echo "include_path=${SERVICE_PATH%/}/**" >> $GITHUB_OUTPUT
+          fi
+
       - name: Generate changelog
         id: cliff
         if: steps.check-tags.outputs.has_tags == 'true'
@@ -189,7 +201,7 @@ jobs:
             --unreleased
             --strip header
             ${{ inputs.service_name != '' && format('--tag-pattern "^{0}-v[0-9]"', inputs.service_name) || '' }}
-            ${{ inputs.service_path != '' && format('--include-path "{0}/**"', inputs.service_path) || '' }}
+            ${{ steps.filter.outputs.include_path != '' && format('--include-path "{0}"', steps.filter.outputs.include_path) || '' }}
         env:
           OUTPUT: /tmp/RELEASE_NOTES.md
 
@@ -202,7 +214,7 @@ jobs:
           args: >-
             --unreleased
             --strip header
-            ${{ inputs.service_path != '' && format('--include-path "{0}/**"', inputs.service_path) || '' }}
+            ${{ steps.filter.outputs.include_path != '' && format('--include-path "{0}"', steps.filter.outputs.include_path) || '' }}
         env:
           OUTPUT: /tmp/RELEASE_NOTES.md
 
@@ -212,6 +224,7 @@ jobs:
           GH_TOKEN: ${{ inputs.app_id != '' && steps.generate-token.outputs.token || github.token }}
         run: |
           SERVICE_NAME="${{ inputs.service_name }}"
+          SERVICE_PATH="${{ inputs.service_path }}"
           HAS_TAGS="${{ steps.check-tags.outputs.has_tags }}"
           IS_DRY_RUN="${{ inputs.dry_run == true || github.event_name == 'pull_request' }}"
 
@@ -232,8 +245,8 @@ jobs:
               exit 0
             fi
           else
-            # First release — check for conventional commits
-            COMMIT_COUNT=$(git log --oneline --format="%s" | grep -cE "^(feat|fix|refactor|perf|docs?|test|chore|ci|style|build)" || true)
+            # First release — check for conventional commits touching this scope
+            COMMIT_COUNT=$(git log --format="%s" -- "${SERVICE_PATH:-.}" | grep -cE "^(feat|fix|refactor|perf|docs?|test|chore|ci|style|build)" || true)
             if [ "$COMMIT_COUNT" -gt 0 ]; then
               VERSION="0.1.0"
               echo "First release detected, defaulting to $VERSION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,10 +18,53 @@ on:
 
 jobs:
   release:
+    name: Umbrella release (whole repo)
     permissions:
       contents: write
     uses: ./.github/workflows/gh-release.yaml
     with:
+      update_version_aliases: true
+      app_id: ${{ vars.FISSION_GH_APP_ID }}
+    secrets:
+      app_private_key: ${{ secrets.FISSION_GH_APP_PRIVATE_KEY }}
+
+  prepare-matrix:
+    name: Enumerate per-workflow release targets
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build workflow matrix
+        id: build
+        run: |
+          matrix=$(
+            for f in .github/workflows/*.yaml; do
+              b=$(basename "$f")
+              case "$b" in
+                _test-*|release.yaml) continue ;;
+              esac
+              grep -q 'workflow_call:' "$f" || continue
+              printf '{"name":"%s","path":"%s"}\n' "${b%.yaml}" "$f"
+            done | jq -sc '{include: .}'
+          )
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "$matrix" | jq .
+
+  release-workflow:
+    name: Release ${{ matrix.name }}
+    needs: prepare-matrix
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
+    uses: ./.github/workflows/gh-release.yaml
+    with:
+      service_name: ${{ matrix.name }}
+      service_path: ${{ matrix.path }}
       update_version_aliases: true
       app_id: ${{ vars.FISSION_GH_APP_ID }}
     secrets:

--- a/README.md
+++ b/README.md
@@ -122,6 +122,21 @@ If the commit message starts with:
 
 otherwise no new release will be created.
 
+### Release scopes
+
+Every merge to main produces two kinds of releases:
+
+- **Umbrella release** — a whole-repo tag (`v<major>.<minor>.<patch>`, e.g. `v4.0.2`) covering all changes. Existing consumers that pin `@v4` keep working unchanged.
+- **Per-workflow releases** — each reusable workflow is versioned independently with a scoped tag `"<workflow>-v<major>.<minor>.<patch>"` (e.g. `gitops-image-tag-v0.1.0`). Only workflows whose file changed in the merge are bumped, based on the conventional-commit type of the commits touching that file. The first release of any workflow is `v0.1.0`.
+
+Scoped releases also maintain moving major/minor alias tags (`gitops-image-tag-v0`, `gitops-image-tag-v0.1`), so consumers can pin a single workflow at whatever granularity they want:
+
+```yaml
+uses: DND-IT/github-workflows/.github/workflows/gitops-image-tag.yaml@gitops-image-tag-v0
+```
+
+Test workflows (`_test-*.yaml`) are excluded from per-workflow releases.
+
 ## Contributing
 
 Before creating a new shared workflow, check if something similar already exists. If it does, consider updating the existing workflow instead of creating a new one.


### PR DESCRIPTION
## What
Adds independent per-workflow versioning while keeping the whole-repo umbrella release.

Each reusable workflow now gets its own scoped tag `<workflow>-vX.Y.Z` (e.g. `gitops-image-tag-v0.1.0`) plus moving aliases (`gitops-image-tag-v0`, `gitops-image-tag-v0.1`). The umbrella `v4.x` release is unchanged, so `@v4` consumers keep working.

## Changes
- **gh-release.yaml**: `service_path` now supports a single **file** (not just a directory) — a new step computes the `--include-path` glob (`file` → exact path, `dir` → `dir/**`). First-release commit count is scoped to the path.
- **release.yaml**: new `prepare-matrix` job enumerates reusable workflows (excludes `_test-*.yaml` and the `release.yaml` orchestrator → 23 targets) and a `fail-fast: false` matrix cuts scoped releases via `gh-release.yaml`. Umbrella release + Slack notify unchanged.
- **_test-gh.yaml**: adds a single-file scoped dry-run test asserting the `gitops-image-tag-v*` tag format.
- **README**: documents umbrella vs per-workflow scopes and per-workflow pinning.

## How this is tested (dry-run, no tags cut)
This PR triggers `release.yaml` in **dry-run** (pull_request context forces it). The matrix will **preview** scoped tags like `gitops-image-tag-v0.1.0`, `tf-apply-v0.1.0`, … in the job logs. No tags are created.

## ⚠️ On first merge to main
The first real run bootstraps **~23 `<workflow>-v0.1.0` tags at once**, plus the umbrella `v4.x`. Subsequent merges only bump workflows whose file changed.

## Local validation
- matrix builder → 23 targets
- `git-cliff --include-path <single file>` accepted; first-release count is path-scoped
- actionlint: no new errors