### PR TITLE
docs(readme): show per-workflow pin granularities and umbrella fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Scoped releases also maintain moving major/minor alias tags (`gitops-image-tag-v
 
 ```yaml
 uses: DND-IT/github-workflows/.github/workflows/gitops-image-tag.yaml@gitops-image-tag-v0
+# or @gitops-image-tag-v0.1  / @gitops-image-tag-v0.1.1  — umbrella @v4 still works
 ```
 
 Test workflows (`_test-*.yaml`) are excluded from per-workflow releases.


### PR DESCRIPTION
Expands the per-workflow pinning example to show the major/minor/patch alias options and note that the umbrella `@v4` still works. Docs-only, no release.