### PR TITLE
feat(docker): add docker_build_args input to ECR build workflows

### DIFF
--- a/.github/workflows/_test-docker-multi-arch.yaml
+++ b/.github/workflows/_test-docker-multi-arch.yaml
@@ -62,6 +62,20 @@ jobs:
       docker_push: true # required to validate the ECR manifest
       docker_platforms: "linux/amd64,linux/arm64"
 
+  test_docker_buildx_build_args:
+    uses: ./.github/workflows/docker-buildx-push-ecr.yaml
+    with:
+      aws_account_id: ${{ vars.aws_account_id }}
+      aws_region: ${{ vars.aws_region }}
+      aws_role_name: ${{ vars.aws_role_name }}
+      image_name: test-docker-buildx-push
+      docker_context: tests/docker
+      dockerfile_path: tests/docker/build-args.Dockerfile
+      docker_push: false
+      docker_platforms: "linux/arm64"
+      docker_build_args: |
+        TEST_BUILD_ARG=expected-value
+
   ## Cleanups
   # TODO: enable after tests finished
   # cleanup_docker_ecr:

--- a/.github/workflows/_test-docker.yaml
+++ b/.github/workflows/_test-docker.yaml
@@ -82,6 +82,19 @@ jobs:
       dockerfile_path: tests/docker/secrets.Dockerfile
       docker_push: false
 
+  test_docker_build_push_ecr_build_args:
+    uses: ./.github/workflows/docker-build-push-ecr.yaml
+    with:
+      aws_account_id: ${{ vars.aws_account_id }}
+      aws_region: ${{ vars.aws_region }}
+      aws_role_name: ${{ vars.aws_role_name }}
+      image_name: test-docker-build-push
+      docker_context: tests/docker
+      dockerfile_path: tests/docker/build-args.Dockerfile
+      docker_push: false
+      docker_build_args: |
+        TEST_BUILD_ARG=expected-value
+
   upload_artifact:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -41,6 +41,11 @@ on:
       docker_target:
         description: "Build target"
         type: string
+      docker_build_args:
+        description: "Additional Docker build arguments (newline-separated KEY=VALUE pairs)"
+        required: false
+        type: string
+        default: ''
       artifact_name:
         description: "Artifact name to be downloaded before building"
         type: string
@@ -118,12 +123,14 @@ jobs:
           DOCKER_CTX: ${{ inputs.docker_context || vars.docker_context || '.' }}
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path || vars.dockerfile_path }} # upstream defaults to {DOCKER_CTX}/Dockerfile
           DOCKER_TARGET: ${{ inputs.docker_target || vars.docker_target }}
+          DOCKER_BUILD_ARGS: ${{ inputs.docker_build_args || vars.docker_build_args }}
           DOCKER_BUILD_SUMMARY: ${{ inputs.docker_build_summary }}
           DOCKER_BUILD_RECORD_UPLOAD: ${{ inputs.docker_build_record_upload }}
         with:
           context: ${{ env.DOCKER_CTX }}
           file: ${{ env.DOCKERFILE_PATH }}
           secrets: ${{ secrets.docker_secrets }}
+          build-args: ${{ env.DOCKER_BUILD_ARGS }}
           # platforms: linux/amd64,linux/arm64 # TODO add support for multi-arch builds
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -28,6 +28,11 @@ on:
       docker_target:
         description: "Build target"
         type: string
+      docker_build_args:
+        description: "Additional Docker build arguments (newline-separated KEY=VALUE pairs)"
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build:
@@ -52,10 +57,12 @@ jobs:
         env:
           DOCKER_CTX: ${{ inputs.docker_context || vars.docker_context || '.'}}
           DOCKER_TARGET: ${{ inputs.docker_target || vars.docker_target }}
+          DOCKER_BUILD_ARGS: ${{ inputs.docker_build_args || vars.docker_build_args }}
         with:
           context: ${{ env.DOCKER_CTX }}
           file: ${{ env.DOCKERFILE_PATH }}
           secrets: ${{ secrets.docker_secrets }}
+          build-args: ${{ env.DOCKER_BUILD_ARGS }}
           # platforms: linux/amd64,linux/arm64 # TODO add support for multi-arch builds
           tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           outputs: type=docker,dest=/tmp/${{ env.IMAGE_NAME }}.tar

--- a/.github/workflows/docker-buildx-push-ecr.yaml
+++ b/.github/workflows/docker-buildx-push-ecr.yaml
@@ -45,6 +45,11 @@ on:
       docker_target:
         description: "Build target"
         type: string
+      docker_build_args:
+        description: "Additional Docker build arguments (newline-separated KEY=VALUE pairs)"
+        required: false
+        type: string
+        default: ''
       docker_platforms:
         description: "Build Platforms. Allowed values: `linux/amd64`, `linux/arm64` and `linux/amd64,linux/arm64`"
         type: string
@@ -156,11 +161,13 @@ jobs:
           DOCKER_CTX: ${{ inputs.docker_context || vars.docker_context || '.' }}
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path || vars.dockerfile_path }} # upstream defaults to {DOCKER_CTX}/Dockerfile
           DOCKER_TARGET: ${{ inputs.docker_target || vars.docker_target }}
+          DOCKER_BUILD_ARGS: ${{ inputs.docker_build_args || vars.docker_build_args }}
           ARCH: ${{ matrix.arch }}
         with:
           context: ${{ env.DOCKER_CTX }}
           file: ${{ env.DOCKERFILE_PATH }}
           secrets: ${{ secrets.docker_secrets }}
+          build-args: ${{ env.DOCKER_BUILD_ARGS }}
           platforms: ${{ matrix.platform }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/docs/workflows/docker-build-push-ecr.md
+++ b/docs/workflows/docker-build-push-ecr.md
@@ -26,6 +26,7 @@ This workflow builds a Docker image and pushes it to the Elastic Container Regis
 | `dockerfile_path` | <p>Path to the Dockerfile. If not defined, will default to {docker_context}/Dockerfile</p> | `string` | `false` | `""` |
 | `docker_push` | <p>Push Image to ECR</p> | `boolean` | `false` | `true` |
 | `docker_target` | <p>Build target</p> | `string` | `false` | `""` |
+| `docker_build_args` | <p>Additional Docker build arguments (newline-separated KEY=VALUE pairs)</p> | `string` | `false` | `""` |
 | `artifact_name` | <p>Artifact name to be downloaded before building</p> | `string` | `false` | `""` |
 | `artifact_path` | <p>Artifact target path</p> | `string` | `false` | `""` |
 | `artifact_pattern` | <p>A glob pattern to the artifacts that should be downloaded. Ignored if name is specified.</p> | `string` | `false` | `""` |
@@ -118,6 +119,13 @@ jobs:
 
       docker_target:
       # Build target
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      docker_build_args:
+      # Additional Docker build arguments (newline-separated KEY=VALUE pairs)
       #
       # Type: string
       # Required: false

--- a/docs/workflows/docker-build.md
+++ b/docs/workflows/docker-build.md
@@ -22,6 +22,7 @@ This workflow builds a Docker image and the artifact is uploaded to the GitHub a
 | `artifact_name` | <p>Name of the artifact to upload. If not set, it will be derived from the image name</p> | `string` | `false` | `""` |
 | `artifact_retention_days` | <p>Number of days to retain the artifact</p> | `number` | `false` | `""` |
 | `docker_target` | <p>Build target</p> | `string` | `false` | `""` |
+| `docker_build_args` | <p>Additional Docker build arguments (newline-separated KEY=VALUE pairs)</p> | `string` | `false` | `""` |
 <!-- action-docs-inputs source=".github/workflows/docker-build.yaml" -->
 
 <!-- action-docs-outputs source=".github/workflows/docker-build.yaml" -->
@@ -80,6 +81,13 @@ jobs:
 
       docker_target:
       # Build target
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      docker_build_args:
+      # Additional Docker build arguments (newline-separated KEY=VALUE pairs)
       #
       # Type: string
       # Required: false

--- a/docs/workflows/docker-buildx-push-ecr.md
+++ b/docs/workflows/docker-buildx-push-ecr.md
@@ -21,6 +21,7 @@ title: Docker Multi-Arch Build and Push to ECR
 | `dockerfile_path` | <p>Path to the Dockerfile. If not defined, will default to {docker_context}/Dockerfile</p> | `string` | `false` | `""` |
 | `docker_push` | <p>Push Image to ECR</p> | `boolean` | `false` | `true` |
 | `docker_target` | <p>Build target</p> | `string` | `false` | `""` |
+| `docker_build_args` | <p>Additional Docker build arguments (newline-separated KEY=VALUE pairs)</p> | `string` | `false` | `""` |
 | `docker_platforms` | <p>Build Platforms. Allowed values: <code>linux/amd64</code>, <code>linux/arm64</code> and <code>linux/amd64,linux/arm64</code></p> | `string` | `false` | `linux/amd64` |
 | `artifact_name` | <p>Artifact name to be downloaded before building</p> | `string` | `false` | `""` |
 | `artifact_path` | <p>Artifact target path</p> | `string` | `false` | `""` |
@@ -119,6 +120,13 @@ jobs:
 
       docker_target:
       # Build target
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      docker_build_args:
+      # Additional Docker build arguments (newline-separated KEY=VALUE pairs)
       #
       # Type: string
       # Required: false

--- a/tests/docker/build-args.Dockerfile
+++ b/tests/docker/build-args.Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3
+ARG TEST_BUILD_ARG
+RUN test "$TEST_BUILD_ARG" = "expected-value" || (echo "TEST_BUILD_ARG not passed" && exit 1)


### PR DESCRIPTION
## Description

Docker build args must be inlined at image build time (e.g. Next.js NEXT_PUBLIC_* values). Previously only service-pipeline.yaml exposed this; the generic docker workflows offered only docker_secrets, which is a different (BuildKit secret) mechanism unusable for ARG values.

Add an optional docker_build_args input (newline-separated KEY=VALUE) to docker-build-push-ecr, docker-buildx-push-ecr, and docker-build, wired via the repo's inputs.x || vars.x fallback. Pass-through only, no injected defaults. Optional with default '', so existing consumers are unaffected (empty build-args is a no-op).

Add tests/docker/build-args.Dockerfile asserting the arg is delivered plus test jobs in _test-docker and _test-docker-multi-arch, and regenerate the action-docs blocks.

## Motivation and Context

Add support for build args required at build time

## Breaking Changes

No. Defaults to current behaviour

## How Has This Been Tested?
- [x] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->