### PR TITLE
feat(tf): add tf_workspace support to tf-plan and tf-apply

### DIFF
--- a/.github/workflows/_test-tf.yaml
+++ b/.github/workflows/_test-tf.yaml
@@ -122,6 +122,47 @@ jobs:
         workspace_key_prefix=github-workflows
       tf_var_files: tests/terraform/s3/environment/sandbox.tfvars
 
+  test_tf_plan_workspace:
+    uses: ./.github/workflows/tf-plan.yaml
+    with:
+      aws_oidc_role_arn: arn:aws:iam::911453050078:role/cicd-iac
+      aws_region: eu-central-1
+      tf_dir: tests/terraform/s3
+      tf_workspace: tf_plan_apply_workspace
+      tf_backend_configs: |
+        bucket=tf-state-911453050078
+        key=test-tf-plan-apply-workspace.tfstate
+        workspace_key_prefix=github-workflows
+      tf_var_files: tests/terraform/s3/environment/sandbox.tfvars
+
+  test_tf_apply_workspace:
+    needs: test_tf_plan_workspace
+    uses: ./.github/workflows/tf-apply.yaml
+    with:
+      aws_oidc_role_arn: arn:aws:iam::911453050078:role/cicd-iac
+      aws_region: eu-central-1
+      tf_dir: tests/terraform/s3
+      tf_workspace: tf_plan_apply_workspace
+      tf_backend_configs: |
+        bucket=tf-state-911453050078
+        key=test-tf-plan-apply-workspace.tfstate
+        workspace_key_prefix=github-workflows
+      tf_var_files: tests/terraform/s3/environment/sandbox.tfvars
+
+  test_tf_cleanup_plan_apply_workspace:
+    needs: test_tf_apply_workspace
+    uses: ./.github/workflows/tf-cleanup.yaml
+    with:
+      aws_oidc_role_arn: arn:aws:iam::911453050078:role/cicd-iac
+      aws_region: eu-central-1
+      tf_dir: tests/terraform/s3
+      tf_workspace: tf_plan_apply_workspace
+      tf_backend_configs: |
+        bucket=tf-state-911453050078
+        key=test-tf-plan-apply-workspace.tfstate
+        workspace_key_prefix=github-workflows
+      tf_var_files: tests/terraform/s3/environment/sandbox.tfvars
+
   test_upload_artifact:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -53,6 +53,9 @@ on:
       tf_pre_run:
         description: "Command to run before Terraform is executed."
         type: string
+      tf_workspace:
+        description: "Terraform workspace"
+        type: string
     outputs:
       tf_outputs:
         description: "List of Terraform outputs captured."
@@ -76,6 +79,12 @@ jobs:
       TF_VAR_FILES: ${{ inputs.tf_var_files || vars.tf_var_files }}
       TF_VARS: ${{ inputs.tf_vars || vars.tf_vars }}
     steps:
+      - name: Sanitise Environment Variables
+        run: |
+          WORKSPACE="${{ inputs.tf_workspace || vars.tf_workspace || 'default' }}"
+          SANITISED_WORKSPACE="${WORKSPACE//\//-}"
+          echo "TF_WORKSPACE=$SANITISED_WORKSPACE" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -104,6 +113,14 @@ jobs:
           pattern: ${{ env.GH_ARTIFACT_PATTERN }}
           merge-multiple: ${{ env.GH_ARTIFACT_MERGE_MULTIPLE }}
 
+      - name: Use Workspace
+        uses: dflook/terraform-new-workspace@ac5eff4d33ad43d8b9c45bcaf4c58cae69313b13 # v2
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          path: ${{ env.TF_DIR }}
+          backend_config: ${{ env.TF_BACKEND_CONFIGS }}
+          backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
+
       - name: Terraform Apply
         id: tf_apply
         uses: dflook/terraform-apply@5489b988934a50bf1489d5b7c5253b46520a7dca # v2
@@ -117,6 +134,7 @@ jobs:
             fi
         with:
           label: ${{ env.ENVIRONMENT }}
+          workspace: ${{ env.TF_WORKSPACE }}
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -59,6 +59,9 @@ on:
       tf_pre_run:
         description: "Command to run before Terraform is executed."
         type: string
+      tf_workspace:
+        description: "Terraform workspace"
+        type: string
 jobs:
   plan:
     permissions:
@@ -76,6 +79,12 @@ jobs:
       TF_VAR_FILES: ${{ inputs.tf_var_files || vars.tf_var_files }}
       TF_VARS: ${{ inputs.tf_vars || vars.tf_vars }}
     steps:
+      - name: Sanitise Environment Variables
+        run: |
+          WORKSPACE="${{ inputs.tf_workspace || vars.tf_workspace || 'default' }}"
+          SANITISED_WORKSPACE="${WORKSPACE//\//-}"
+          echo "TF_WORKSPACE=$SANITISED_WORKSPACE" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -118,6 +127,14 @@ jobs:
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
 
+      - name: Use Workspace
+        uses: dflook/terraform-new-workspace@ac5eff4d33ad43d8b9c45bcaf4c58cae69313b13 # v2
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          path: ${{ env.TF_DIR }}
+          backend_config: ${{ env.TF_BACKEND_CONFIGS }}
+          backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
+
       - name: Terraform Plan
         id: plan
         uses: dflook/terraform-plan@7878bff63e2099cdc9be9a6f33cbbbf687f8f0fe # v2
@@ -132,6 +149,7 @@ jobs:
         with:
           label: ${{ env.ENVIRONMENT }}
           add_github_comment: ${{ inputs.gh_comment }}
+          workspace: ${{ env.TF_WORKSPACE }}
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}

--- a/docs/workflows/tf-apply.md
+++ b/docs/workflows/tf-apply.md
@@ -31,6 +31,7 @@ This workflow applies the Terraform configuration.
 | `tf_var_files` | <p>List of tfvars files to use, one per line. Paths should be relative to the GitHub Actions workspace.</p> | `string` | `false` | `""` |
 | `tf_vars` | <p>Variables to set for the Terraform plan. This should be valid Terraform syntax.</p> | `string` | `false` | `""` |
 | `tf_pre_run` | <p>Command to run before Terraform is executed.</p> | `string` | `false` | `""` |
+| `tf_workspace` | <p>Terraform workspace</p> | `string` | `false` | `""` |
 <!-- action-docs-inputs source=".github/workflows/tf-apply.yaml" -->
 
 <!-- action-docs-outputs source=".github/workflows/tf-apply.yaml" -->
@@ -156,6 +157,13 @@ jobs:
 
       tf_pre_run:
       # Command to run before Terraform is executed.
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      tf_workspace:
+      # Terraform workspace
       #
       # Type: string
       # Required: false

--- a/docs/workflows/tf-plan.md
+++ b/docs/workflows/tf-plan.md
@@ -32,6 +32,7 @@ This workflow runs `terraform plan` and uploads the plan to Github Action summar
 | `tf_var_files` | <p>List of tfvars files to use, one per line. Paths should be relative to the GitHub Actions workspace.</p> | `string` | `false` | `""` |
 | `tf_vars` | <p>Variables to set for the Terraform plan. This should be valid Terraform syntax.</p> | `string` | `false` | `""` |
 | `tf_pre_run` | <p>Command to run before Terraform is executed.</p> | `string` | `false` | `""` |
+| `tf_workspace` | <p>Terraform workspace</p> | `string` | `false` | `""` |
 <!-- action-docs-inputs source=".github/workflows/tf-plan.yaml" -->
 
 <!-- action-docs-outputs source=".github/workflows/tf-plan.yaml" -->
@@ -160,6 +161,13 @@ jobs:
 
       tf_pre_run:
       # Command to run before Terraform is executed.
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      tf_workspace:
+      # Terraform workspace
       #
       # Type: string
       # Required: false


### PR DESCRIPTION
## Description
Adds `tf_workspace` input support to `tf-plan` and `tf-apply`, mirroring the pattern already used in `tf-feature`/`tf-cleanup`: sanitise the workspace name, ensure it exists via `dflook/terraform-new-workspace`, then pass it through to the plan/apply action.

## Motivation and Context
`tf-plan`/`tf-apply` previously had no way to target a non-default Terraform workspace, unlike `tf-feature`/`tf-cleanup`.

## Breaking Changes
None. The workspace fallback defaults to `"default"` (the pre-existing implicit behavior), not the branch name used by `tf-feature`, so existing callers that don't set `tf_workspace` are unaffected.

## How Has This Been Tested?
- [x] Added `test_tf_plan_workspace` → `test_tf_apply_workspace` → `test_tf_cleanup_plan_apply_workspace` chain to `_test-tf.yaml` exercising a named workspace end-to-end
- [x] Ran `pre-commit run -a`
- [x] Ran `make gen_docs_run` and updated `docs/workflows/tf-plan.md` / `tf-apply.md`