### PR TITLE
feat(tf): expose GitHub App auth as TF_VAR inputs on tf-plan/tf-apply

### DIFF
--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -56,6 +56,13 @@ on:
       tf_workspace:
         description: "Terraform workspace"
         type: string
+      app_id:
+        description: "GitHub App ID, exposed to the apply as the github_app_id Terraform variable (via TF_VAR_github_app_id). Pair with the app_private_key secret to authenticate a `github` Terraform provider."
+        type: string
+    secrets:
+      app_private_key:
+        description: "GitHub App private key (PEM), exposed to the apply as the github_app_private_key Terraform variable (via TF_VAR_github_app_private_key)."
+        required: false
     outputs:
       tf_outputs:
         description: "List of Terraform outputs captured."
@@ -78,6 +85,8 @@ jobs:
       TF_BACKEND_CONFIG_FILES: ${{ inputs.tf_backend_config_files || vars.tf_backend_config_files }}
       TF_VAR_FILES: ${{ inputs.tf_var_files || vars.tf_var_files }}
       TF_VARS: ${{ inputs.tf_vars || vars.tf_vars }}
+      TF_VAR_github_app_id: ${{ inputs.app_id || vars.app_id }}
+      TF_VAR_github_app_private_key: ${{ secrets.app_private_key }}
     steps:
       - name: Sanitise Environment Variables
         run: |

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -62,6 +62,13 @@ on:
       tf_workspace:
         description: "Terraform workspace"
         type: string
+      app_id:
+        description: "GitHub App ID, exposed to the plan as the github_app_id Terraform variable (via TF_VAR_github_app_id). Pair with the app_private_key secret to authenticate a `github` Terraform provider."
+        type: string
+    secrets:
+      app_private_key:
+        description: "GitHub App private key (PEM), exposed to the plan as the github_app_private_key Terraform variable (via TF_VAR_github_app_private_key)."
+        required: false
 jobs:
   plan:
     permissions:
@@ -78,6 +85,8 @@ jobs:
       TF_BACKEND_CONFIG_FILES: ${{ inputs.tf_backend_config_files || vars.tf_backend_config_files }}
       TF_VAR_FILES: ${{ inputs.tf_var_files || vars.tf_var_files }}
       TF_VARS: ${{ inputs.tf_vars || vars.tf_vars }}
+      TF_VAR_github_app_id: ${{ inputs.app_id || vars.app_id }}
+      TF_VAR_github_app_private_key: ${{ secrets.app_private_key }}
     steps:
       - name: Sanitise Environment Variables
         run: |

--- a/docs/workflows/tf-apply.md
+++ b/docs/workflows/tf-apply.md
@@ -32,6 +32,7 @@ This workflow applies the Terraform configuration.
 | `tf_vars` | <p>Variables to set for the Terraform plan. This should be valid Terraform syntax.</p> | `string` | `false` | `""` |
 | `tf_pre_run` | <p>Command to run before Terraform is executed.</p> | `string` | `false` | `""` |
 | `tf_workspace` | <p>Terraform workspace</p> | `string` | `false` | `""` |
+| `app_id` | <p>GitHub App ID, exposed to the apply as the github<em>app</em>id Terraform variable (via TF<em>VAR</em>github<em>app</em>id). Pair with the app<em>private</em>key secret to authenticate a <code>github</code> Terraform provider.</p> | `string` | `false` | `""` |
 <!-- action-docs-inputs source=".github/workflows/tf-apply.yaml" -->
 
 <!-- action-docs-outputs source=".github/workflows/tf-apply.yaml" -->
@@ -164,6 +165,13 @@ jobs:
 
       tf_workspace:
       # Terraform workspace
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      app_id:
+      # GitHub App ID, exposed to the apply as the github_app_id Terraform variable (via TF_VAR_github_app_id). Pair with the app_private_key secret to authenticate a `github` Terraform provider.
       #
       # Type: string
       # Required: false

--- a/docs/workflows/tf-plan.md
+++ b/docs/workflows/tf-plan.md
@@ -33,6 +33,7 @@ This workflow runs `terraform plan` and uploads the plan to Github Action summar
 | `tf_vars` | <p>Variables to set for the Terraform plan. This should be valid Terraform syntax.</p> | `string` | `false` | `""` |
 | `tf_pre_run` | <p>Command to run before Terraform is executed.</p> | `string` | `false` | `""` |
 | `tf_workspace` | <p>Terraform workspace</p> | `string` | `false` | `""` |
+| `app_id` | <p>GitHub App ID, exposed to the plan as the github<em>app</em>id Terraform variable (via TF<em>VAR</em>github<em>app</em>id). Pair with the app<em>private</em>key secret to authenticate a <code>github</code> Terraform provider.</p> | `string` | `false` | `""` |
 <!-- action-docs-inputs source=".github/workflows/tf-plan.yaml" -->
 
 <!-- action-docs-outputs source=".github/workflows/tf-plan.yaml" -->
@@ -168,6 +169,13 @@ jobs:
 
       tf_workspace:
       # Terraform workspace
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      app_id:
+      # GitHub App ID, exposed to the plan as the github_app_id Terraform variable (via TF_VAR_github_app_id). Pair with the app_private_key secret to authenticate a `github` Terraform provider.
       #
       # Type: string
       # Required: false


### PR DESCRIPTION
## Summary
- Consumers whose Terraform code needs a `github` (or similar) provider authenticated as a GitHub App had no way to get those credentials into the plan/apply run. Secrets aren't a valid context in a caller's `with:` block for a `workflow_call`, and passing a minted installation token through job outputs gets silently redacted (GitHub Actions treats any output that transitively derives from a secret as itself secret, even after transformation like base64).
- Adds an optional `app_id` input and `app_private_key` secret to both `tf-plan.yaml` and `tf-apply.yaml`, exposed to the Terraform run as `TF_VAR_github_app_id` / `TF_VAR_github_app_private_key`. Consumers can then reference `var.github_app_id` / `var.github_app_private_key` in an `app_auth` provider block.
- Both new inputs are optional and empty by default, so this is a no-op for every existing caller.

Motivating use case: `tx-pts-dai/dai-infrastructure` needs to dynamically look up GitHub repository/owner IDs (for the new [immutable OIDC subject format](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims)) via the `integrations/github` Terraform provider, authenticated as their FISSION GitHub App.

## Test plan
- [x] `actionlint` clean on both modified files (pre-existing unrelated findings confirmed present before this change too)
- [x] Docs regenerated via `make gen_docs_run` (`docs/workflows/tf-plan.md`, `docs/workflows/tf-apply.md`)
- [x] Existing `_test-tf.yaml` doesn't reference these names, so should be unaffected
- [ ] End-to-end verification from `tx-pts-dai/dai-infrastructure` once this merges and releases